### PR TITLE
Support the use in incognito/inprivate mode

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -22,5 +22,8 @@
     },
     "theme_dark": {
         "message": "Dark"
+    },
+    "in_incognito": {
+        "message": "Current window is in incognito/inprivate mode"
     }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -22,5 +22,8 @@
     },
     "theme_dark": {
         "message": "深色"
+    },
+    "in_incognito": {
+        "message": "当前窗口正处于 incognito/inprivate 模式"
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -26,5 +26,6 @@
     "permissions": [
         "storage"
     ],
+    "incognito": "split",
     "default_locale": "en"
 }

--- a/src/blank.html
+++ b/src/blank.html
@@ -22,6 +22,10 @@
         .theme-dark {
             background-color: #333333;
         }
+
+        .theme-incognito {
+            background-color: #222222;
+        }
     </style>
     <script src="blank.js"></script>
 </head>

--- a/src/blank.js
+++ b/src/blank.js
@@ -5,6 +5,10 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 function loadOptions() {
+    if (chrome.extension.inIncognitoContext) {
+        document.body.className = 'theme-incognito';
+        return;
+    }
     chrome.storage.local.get(['theme'], result => {
         if (!result.theme) {
             result.theme = 'light';

--- a/src/options.html
+++ b/src/options.html
@@ -7,6 +7,7 @@
         body {
             background-color: white;
             margin: 0px;
+            height: fit-content;
         }
 
         .options-card {
@@ -62,6 +63,18 @@
             margin: 0px 10px 0px 10px;
             font-size: 14px;
         }
+
+        #in-incognito {
+            white-space: nowrap;
+            padding: 10px;
+            font-size: 16px;
+            color: white;
+            background-color: #222222;
+        }
+
+        .hide {
+            display: none;
+        }
     </style>
 </head>
 
@@ -92,6 +105,7 @@
             </label>
         </div>
     </div>
+    <div id="in-incognito" class="hide"></div>
     <script src="options.js"></script>
 </body>
 

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,13 @@
 document.addEventListener('DOMContentLoaded', function () {
     document.title = chrome.i18n.getMessage("options");
+    if (chrome.extension.inIncognitoContext) {
+        let incognito = document.getElementById('in-incognito');
+        incognito.innerText = chrome.i18n.getMessage("in_incognito");
+        incognito.classList.remove('hide');
+        let theme = document.getElementById('theme');
+        theme.classList.add('hide');
+        return;
+    }
     document.querySelectorAll('[data-locale]').forEach(elem => {
         elem.innerText = chrome.i18n.getMessage(elem.dataset.locale);
     });


### PR DESCRIPTION
Set "incognito" manifest key to "split" to allow new tab overriding in incognito mode. https://developer.chrome.com/docs/extensions/mv3/manifest/incognito/
Use `chrome.extension.inIncognitoContext` to check if the extension is running in incognito process.
https://developer.chrome.com/docs/extensions/reference/extension/#property-inIncognitoContext